### PR TITLE
Add ActionCable engine

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -4,7 +4,7 @@ require_relative "boot"
 
 require "decidim/rails"
 # Add the frameworks used by your app that are not loaded by Decidim.
-# require "action_cable/engine"
+require "action_cable/engine"
 # require "action_mailbox/engine"
 # require "action_text/engine"
 


### PR DESCRIPTION
Include `ActionCable` engine to avoid the error: `uninitialized constant ApplicationCable::ActionCable (NameError)`